### PR TITLE
Breadcrumbs shows all the nodes even those who are not in the selectedAsset path

### DIFF
--- a/px-context-browser.html
+++ b/px-context-browser.html
@@ -183,7 +183,7 @@ This method expects 2 things to be true:
          * @default Empty Object
          * ```html
          *   <px-context-browser
-	       *      ...
+         *      ...
          *      browser-context={{browserContext}}>
          *    </px-context-browser>
          * ```
@@ -521,21 +521,19 @@ This method expects 2 things to be true:
             if (currentRoot.hasOwnProperty(i)) {
               current_elem = currentRoot[i];
               if(Object.keys(current_elem).indexOf('children') > -1 ) {
-                  current_elem.inSelectedPath = true;
-                //only direct lineage of the selected child have children..
-                _this.push('parentNodes',current_elem);
+                if (current_elem.inSelectedPath) {
+                  _this.push('parentNodes',current_elem);
+                }
                 if (current_elem.selectedAsset) {
-                    current_elem.inSelectedPath = true;
+                    _this.addParents(current_elem);
                     _this.set('selectedItem',current_elem);
                 }
                 var obj = {"data" : current_elem.children};
                 _this.addChildren(current_elem, obj);
                 recursiveAddChildren(current_elem.children);
               } else if (current_elem.selectedAsset) {
-                  current_elem.inSelectedPath = true;
-                  _this.set('selectedItem',current_elem);
-                //we're pushing this item into parentNode to ensure the breadcrumbs work correctly.
-                _this.push('parentNodes',current_elem);
+                _this.addParents(current_elem);                
+                _this.set('selectedItem',current_elem);
               }
             }
           }
@@ -545,6 +543,26 @@ This method expects 2 things to be true:
         if (this.selectedItem && this.selectedItem.name) {
           this.configureBreadcrumbs();
           this.openedItemName = this.selectedItem.name;
+        }
+      },
+     /**
+      * Add parents to the parentNodes array so that the breadcrumbs will have the correct path
+      * 
+      * @param {Object} item The selected item (with selectedAsset to true) 
+      */
+      addParents: function(item) {
+        var array = [];
+        var parent = item;
+
+        while (parent) {
+          parent.inSelectedPath = true;
+          if (parent.parent) {
+            array.push(parent);
+          }                  
+          parent = parent.parent;
+        }
+        for (var i = array.length - 1; i >= 0; i--) {
+          this.push('parentNodes',array[i]);
         }
       },
       /**


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
When we have multiple branches with children, if we put a "selectedAsset": true to any of them, the breadcrumbs have all the nodes shown at first time, even those who aren't parents of the selected asset.

* ## A reference to a related issue (if applicable):
None.

* ## @mentions of the person or team responsible for reviewing proposed changes:
@runn-vermel 

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
Just add a children to **"identifier": "001-1"** in **directContext.json** and test with and without my modifications.