### PR TITLE
Only show spinner when getChildren handler is defined.

### DIFF
--- a/px-context-browser.html
+++ b/px-context-browser.html
@@ -669,8 +669,8 @@ This method expects 2 things to be true:
        * @private
        */
       getNewChildren: function(item) {
-        this.spinner('show');
         if (this.handlers.getChildren) {
+          this.spinner('show');
           var _this = this;
           this.handlers.getChildren(item).then(
             function(data) {


### PR DESCRIPTION
Fixes a small issue I had where all my data was sent over one request, so I didn't require a getChildren handler.

Spinner kept showing up anyway.