### PR TITLE
fix: judge `children` is empty or not

### DIFF
--- a/px-context-browser.html
+++ b/px-context-browser.html
@@ -519,7 +519,7 @@ Custom property | Description | Default
        * @private
        */
       _hasChildren: function(item) {
-        return (this.showChevron) ? (item.hasChildren || item.children) : false;
+        return (this.showChevron) ? (item.hasChildren || (item.children && item.children.length)) : false;
       },
       /**
        * Observer on context attribute. loads up the initial Context of the browser.


### PR DESCRIPTION
In your API docs, the field `children` is Array typed, so we should judge `children` as an array
