### PR TITLE
fix directContext setting - children of selected asset not properly…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bower_components
 .idea
 reports
 css/noprefix
+*.iml

--- a/px-context-browser.html
+++ b/px-context-browser.html
@@ -643,7 +643,9 @@ Custom property | Description | Default
               // we make sure to set this to true, so when we loop around again, we know that we've found 
               //the selectedAsset
               selectedAssetFound = true;
-              continue;
+              // this continue prevents children of the selected asset to be added properly. Clicking on a child
+				// results in a javascript error.
+              // continue;
             }
             //in case the currentChild we're on has children, as add them, and recuresively call ourselves.
             if(Object.keys(currentChild).indexOf('children') > -1 ) {


### PR DESCRIPTION
… initialized

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:

This is a bug fix - when we pass an initial browser context that includes a selectedAsset, and that selected asset has children, then the children of that asset are not properly initialized in the context browser. The result is that when the browser is opened and one of the children clicked on, the following javascript error occurs:

`px-context-browser.html:896 Uncaught TypeError: Cannot read property 'children' of undefined
    at HTMLElement.changeSelected (px-context-browser.html:896)
    at px-context-browser.html:866`

The one-line change removes a `continue` statement in recursiveAddChildren that effectively skips processing the children of the selected asset. All current wct tests continue to pass.

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
