### PR TITLE
Add an onRejected promise handler for to getChildren

### DIFF
--- a/px-context-browser.html
+++ b/px-context-browser.html
@@ -843,7 +843,12 @@ Custom property | Description | Default
               } else {
                 // disregard response, it's from an old getChildren call
               }
-          });
+            },
+            function(error) {
+              _this.spinner('hide');
+              console.warn('Context tree getChildren failed');
+            }
+          );
         }
       },
 


### PR DESCRIPTION
We came across a scenario when using the px-context-browser where the call to getChildren would internally get a server error due to a timeout retrieving assets from APM.  This appears to be a regular occurrence.
Our immediate problem was that the spinner would never go away until we refreshed the page.
We have temporarily handled this ourselves by having our getChildren return an empty array of children, while keeping the existing parent context.  However this pushed our error condition through the success functionality in getNewChildren.  A better solution would be to have the getNewChildren be able to handle the error condition, and log a warning as it appears that many other clients would come across this scenario.

We have tested this with our implementation, and it allows us to simply allow the user to retry getting the children, while knowing why the error happened in the first place.

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
